### PR TITLE
fix(ci): publish long sha tag for docker image

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -77,7 +77,7 @@ jobs:
             # Latest tag for default branch
             type=raw,value=latest,enable={{is_default_branch}}
             # SHA for traceability
-            type=sha,prefix=sha-
+            type=sha,prefix=sha-,format=long
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6


### PR DESCRIPTION
metadata-action uses short SHA by default, but test job pulls sha-${{ github.sha }}. Use format=long to ensure the pushed tag matches the pull tag.