### PR TITLE
fix: remove mandatory API key check and add LLM gateway support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 node_modules/
 .opencode-review/node_modules/
 
+# Packages (development only)
+packages/
+
 # Bun
 *.lockb
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Configure the following secrets in your Gitea repository:
 |-------------|-------------|
 | `OPENCODE_GIT_TOKEN` | Gitea API Token (requires repo permissions) |
 | `DEEPSEEK_API_KEY` | DeepSeek API Key (default model) |
+| `ANTHROPIC_API_KEY` | Anthropic API Key (optional) |
+| `OPENAI_API_KEY` | OpenAI API Key (optional) |
 
 ### 2. Configure Model (Optional)
 
@@ -77,7 +79,32 @@ env:
   # MODEL: openai/gpt-4o                # Requires OPENAI_API_KEY
 ```
 
-### 3. Review Configuration
+### 3. Using LLM Gateways (Optional)
+
+You can use LLM gateways like **LiteLLM**, **OpenRouter**, **Together AI**, **NVIDIA NIM**, etc. via the OpenAI-compatible API:
+
+```yaml
+env:
+  # Point MODEL to an OpenAI-compatible provider
+  MODEL: openai/your-model-name
+  OPENAI_API_KEY: ${{ secrets.YOUR_API_KEY }}
+  # Set the gateway URL
+  OPENAI_BASE_URL: "https://openrouter.ai/api/v1"    # OpenRouter
+  # OPENAI_BASE_URL: "http://localhost:4000/v1"        # LiteLLM
+  # OPENAI_BASE_URL: "https://api.together.xyz/v1"     # Together AI
+```
+
+| Gateway | OPENAI_BASE_URL | Notes |
+|---------|-----------------|-------|
+| OpenRouter | `https://openrouter.ai/api/v1` | Use `OPENROUTER_API_KEY` |
+| LiteLLM | `http://localhost:4000/v1` | Self-hosted proxy |
+| Together AI | `https://api.together.xyz/v1` | |
+| NVIDIA NIM | `https://integrate.api.nvidia.com/v1` | |
+| Ollama (local) | `http://localhost:11434/v1` | No API key needed |
+
+> **Note**: When using gateways, set `MODEL` to `openai/<model-name>` so opencode routes through the OpenAI-compatible provider.
+
+### 4. Review Configuration
 
 These options work with both Docker and Source installations:
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -64,6 +64,8 @@ curl -fsSL https://raw.githubusercontent.com/ccsert/opencode-review-gitea/main/i
 |------------|------|
 | `OPENCODE_GIT_TOKEN` | Gitea API Token（需要 repo 权限） |
 | `DEEPSEEK_API_KEY` | DeepSeek API Key（默认模型） |
+| `ANTHROPIC_API_KEY` | Anthropic API Key（可选） |
+| `OPENAI_API_KEY` | OpenAI API Key（可选） |
 
 ### 2. 配置模型（可选）
 
@@ -77,7 +79,32 @@ env:
   # MODEL: openai/gpt-4o                # 需要 OPENAI_API_KEY
 ```
 
-### 3. 审查配置
+### 3. 使用 LLM 网关（可选）
+
+你可以通过 OpenAI 兼容 API 使用 **LiteLLM**、**OpenRouter**、**Together AI**、**NVIDIA NIM** 等 LLM 网关：
+
+```yaml
+env:
+  # 将 MODEL 指向 OpenAI 兼容的 provider
+  MODEL: openai/your-model-name
+  OPENAI_API_KEY: ${{ secrets.YOUR_API_KEY }}
+  # 设置网关 URL
+  OPENAI_BASE_URL: "https://openrouter.ai/api/v1"    # OpenRouter
+  # OPENAI_BASE_URL: "http://localhost:4000/v1"        # LiteLLM
+  # OPENAI_BASE_URL: "https://api.together.xyz/v1"     # Together AI
+```
+
+| 网关 | OPENAI_BASE_URL | 备注 |
+|------|-----------------|------|
+| OpenRouter | `https://openrouter.ai/api/v1` | 使用 `OPENROUTER_API_KEY` |
+| LiteLLM | `http://localhost:4000/v1` | 自建代理 |
+| Together AI | `https://api.together.xyz/v1` | |
+| NVIDIA NIM | `https://integrate.api.nvidia.com/v1` | |
+| Ollama（本地） | `http://localhost:11434/v1` | 无需 API Key |
+
+> **注意**: 使用网关时，请将 `MODEL` 设置为 `openai/<模型名称>`，以便 opencode 通过 OpenAI 兼容 provider 路由请求。
+
+### 4. 审查配置
 
 以下选项适用于 Docker 和源码两种安装方式：
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -54,17 +54,21 @@ validate_env() {
         missing+=("GITEA_SERVER_URL or GITHUB_SERVER_URL")
     fi
 
-    # Check for at least one LLM API key
-    if [ -z "$DEEPSEEK_API_KEY" ] && [ -z "$ANTHROPIC_API_KEY" ] && [ -z "$OPENAI_API_KEY" ]; then
-        missing+=("DEEPSEEK_API_KEY, ANTHROPIC_API_KEY, or OPENAI_API_KEY")
-    fi
-    
     if [ ${#missing[@]} -gt 0 ]; then
         log_error "Missing required environment variables:"
         for var in "${missing[@]}"; do
             echo "  - $var"
         done
         exit 1
+    fi
+
+    # Warn if no LLM API key is set (not fatal - some providers don't need one)
+    if [ -z "$DEEPSEEK_API_KEY" ] && [ -z "$ANTHROPIC_API_KEY" ] && \
+       [ -z "$OPENAI_API_KEY" ] && [ -z "$LLM_API_KEY" ] && \
+       [ -z "$OPENROUTER_API_KEY" ] && [ -z "$OPENAI_BASE_URL" ]; then
+        log_warn "No LLM API key detected (DEEPSEEK_API_KEY, ANTHROPIC_API_KEY, OPENAI_API_KEY, LLM_API_KEY, OPENROUTER_API_KEY)"
+        log_warn "If you are using a local model or custom gateway, you can ignore this warning"
+        log_warn "Set OPENAI_BASE_URL to use an OpenAI-compatible gateway (LiteLLM, OpenRouter, etc.)"
     fi
     
     log_success "Environment validated"
@@ -247,9 +251,17 @@ main() {
             echo "Environment Variables:"
             echo "  GITEA_TOKEN        Gitea API token (required)"
             echo "  GITEA_SERVER_URL   Base URL like https://gitea.example.com (required)"
+            echo ""
+            echo "  LLM API Keys (at least one recommended):"
             echo "  DEEPSEEK_API_KEY   DeepSeek API key"
             echo "  ANTHROPIC_API_KEY  Anthropic API key"
             echo "  OPENAI_API_KEY     OpenAI API key"
+            echo "  LLM_API_KEY        Generic API key for other providers"
+            echo "  OPENROUTER_API_KEY OpenRouter API key"
+            echo ""
+            echo "  LLM Gateway (for LiteLLM, OpenRouter, Together AI, etc.):"
+            echo "  OPENAI_BASE_URL    Custom API base URL (e.g., http://localhost:4000/v1)"
+            echo ""
             echo "  MODEL              AI model (default: deepseek/deepseek-chat)"
             echo "  REVIEW_LANGUAGE    auto|en|zh-CN (default: auto)"
             echo "  REVIEW_STYLE       concise|balanced|thorough|security (default: balanced)"

--- a/templates/workflow-docker.yaml
+++ b/templates/workflow-docker.yaml
@@ -57,6 +57,9 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           
+          # LLM Gateway (optional, for LiteLLM, OpenRouter, Together AI, etc.)
+          # OPENAI_BASE_URL: ""          # e.g., http://localhost:4000/v1
+          
           # PR context
           PR_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
           REPO_OWNER: ${{ github.repository_owner }}

--- a/templates/workflow-source.yaml
+++ b/templates/workflow-source.yaml
@@ -69,6 +69,9 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           
+          # LLM Gateway (optional, for LiteLLM, OpenRouter, Together AI, etc.)
+          # OPENAI_BASE_URL: ""          # e.g., http://localhost:4000/v1
+          
           # PR context
           PR_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
           REPO_OWNER: ${{ github.repository_owner }}


### PR DESCRIPTION
## Summary

- **Fixes #13**: Remove mandatory API key validation in Docker mode. API key check is now a warning instead of a hard error, allowing use with free/local models or custom gateways that don't require standard API keys.
- **Fixes #15**: Add LLM Gateway configuration support and documentation. Users can now configure OpenAI-compatible gateways (OpenRouter, LiteLLM, Together AI, NVIDIA NIM, Ollama) via `OPENAI_BASE_URL` environment variable.

## Changes

| File | Change |
|------|--------|
| `entrypoint.sh` | API key check → warning; add `LLM_API_KEY`, `OPENROUTER_API_KEY`, `OPENAI_BASE_URL` recognition; update help text |
| `README.md` | Add "Using LLM Gateways" section with gateway examples |
| `README_zh.md` | Add Chinese LLM Gateway docs; update secrets table |
| `templates/workflow-docker.yaml` | Add `OPENAI_BASE_URL` env var |
| `templates/workflow-source.yaml` | Add `OPENAI_BASE_URL` env var |
| `.gitignore` | Add `packages/` directory |