### PR TITLE
fix: improve API error handling and add ARM architecture detection

### DIFF
--- a/.opencode-review/tools/gitea-comment.ts
+++ b/.opencode-review/tools/gitea-comment.ts
@@ -12,13 +12,18 @@ import DESCRIPTION from "./gitea-comment.txt"
  *   GITEA_SERVER_URL - Base URL (e.g., https://gitea.example.com)
  */
 
+function normalizeBaseUrl(url: string): string {
+  return url.replace(/\/+$/, "").replace(/\/api\/v1\/?$/, "")
+}
+
 async function giteaFetch(endpoint: string, options: RequestInit = {}) {
-  const baseUrl = process.env.GITEA_SERVER_URL || process.env.GITHUB_SERVER_URL
+  const rawUrl = process.env.GITEA_SERVER_URL || process.env.GITHUB_SERVER_URL
   const token = process.env.GITEA_TOKEN || process.env.GITHUB_TOKEN
 
-  if (!baseUrl) throw new Error("GITEA_SERVER_URL environment variable is required")
+  if (!rawUrl) throw new Error("GITEA_SERVER_URL environment variable is required")
   if (!token) throw new Error("GITEA_TOKEN environment variable is required")
 
+  const baseUrl = normalizeBaseUrl(rawUrl)
   const url = `${baseUrl}/api/v1${endpoint}`
   const response = await fetch(url, {
     ...options,
@@ -32,6 +37,16 @@ async function giteaFetch(endpoint: string, options: RequestInit = {}) {
 
   if (!response.ok) {
     const text = await response.text()
+    if (response.status === 404) {
+      throw new Error(
+        `Gitea API error: 404 Not Found for ${url}\n` +
+        `Possible causes:\n` +
+        `  - GITEA_SERVER_URL is incorrect (current: ${rawUrl})\n` +
+        `  - Repository or PR does not exist\n` +
+        `  - Token does not have access to this resource\n` +
+        `Response: ${text}`
+      )
+    }
     throw new Error(`Gitea API error: ${response.status} ${response.statusText} - ${text}`)
   }
 

--- a/.opencode-review/tools/gitea-incremental-diff.ts
+++ b/.opencode-review/tools/gitea-incremental-diff.ts
@@ -44,13 +44,18 @@ interface PRInfo {
   merged: boolean
 }
 
+function normalizeBaseUrl(url: string): string {
+  return url.replace(/\/+$/, "").replace(/\/api\/v1\/?$/, "")
+}
+
 async function giteaFetch(endpoint: string, options: RequestInit = {}) {
-  const baseUrl = process.env.GITEA_SERVER_URL || process.env.GITHUB_SERVER_URL
+  const rawUrl = process.env.GITEA_SERVER_URL || process.env.GITHUB_SERVER_URL
   const token = process.env.GITEA_TOKEN || process.env.GITHUB_TOKEN
 
-  if (!baseUrl) throw new Error("GITEA_SERVER_URL environment variable is required")
+  if (!rawUrl) throw new Error("GITEA_SERVER_URL environment variable is required")
   if (!token) throw new Error("GITEA_TOKEN environment variable is required")
 
+  const baseUrl = normalizeBaseUrl(rawUrl)
   const url = `${baseUrl}/api/v1${endpoint}`
   
   // Build headers properly
@@ -74,6 +79,16 @@ async function giteaFetch(endpoint: string, options: RequestInit = {}) {
 
   if (!response.ok) {
     const text = await response.text()
+    if (response.status === 404) {
+      throw new Error(
+        `Gitea API error: 404 Not Found for ${url}\n` +
+        `Possible causes:\n` +
+        `  - GITEA_SERVER_URL is incorrect (current: ${rawUrl})\n` +
+        `  - Repository or PR does not exist\n` +
+        `  - Token does not have access to this resource\n` +
+        `Response: ${text}`
+      )
+    }
     throw new Error(`Gitea API error: ${response.status} ${response.statusText} - ${text}`)
   }
 

--- a/.opencode-review/tools/gitea-pr-diff.ts
+++ b/.opencode-review/tools/gitea-pr-diff.ts
@@ -12,13 +12,18 @@ import DESCRIPTION from "./gitea-pr-diff.txt"
  *   GITEA_SERVER_URL - Base URL (e.g., https://gitea.example.com)
  */
 
+function normalizeBaseUrl(url: string): string {
+  return url.replace(/\/+$/, "").replace(/\/api\/v1\/?$/, "")
+}
+
 async function giteaFetch(endpoint: string, options: RequestInit = {}) {
-  const baseUrl = process.env.GITEA_SERVER_URL || process.env.GITHUB_SERVER_URL
+  const rawUrl = process.env.GITEA_SERVER_URL || process.env.GITHUB_SERVER_URL
   const token = process.env.GITEA_TOKEN || process.env.GITHUB_TOKEN
 
-  if (!baseUrl) throw new Error("GITEA_SERVER_URL environment variable is required")
+  if (!rawUrl) throw new Error("GITEA_SERVER_URL environment variable is required")
   if (!token) throw new Error("GITEA_TOKEN environment variable is required")
 
+  const baseUrl = normalizeBaseUrl(rawUrl)
   const url = `${baseUrl}/api/v1${endpoint}`
   const response = await fetch(url, {
     ...options,
@@ -30,6 +35,16 @@ async function giteaFetch(endpoint: string, options: RequestInit = {}) {
 
   if (!response.ok) {
     const text = await response.text()
+    if (response.status === 404) {
+      throw new Error(
+        `Gitea API error: 404 Not Found for ${url}\n` +
+        `Possible causes:\n` +
+        `  - GITEA_SERVER_URL is incorrect (current: ${rawUrl})\n` +
+        `  - Repository or PR does not exist\n` +
+        `  - Token does not have access to this resource\n` +
+        `Response: ${text}`
+      )
+    }
     throw new Error(`Gitea API error: ${response.status} ${response.statusText} - ${text}`)
   }
 

--- a/.opencode-review/tools/gitea-pr-files.ts
+++ b/.opencode-review/tools/gitea-pr-files.ts
@@ -12,13 +12,18 @@ import { tool } from "@opencode-ai/plugin"
  *   GITEA_SERVER_URL - Base URL (e.g., https://gitea.example.com)
  */
 
+function normalizeBaseUrl(url: string): string {
+  return url.replace(/\/+$/, "").replace(/\/api\/v1\/?$/, "")
+}
+
 async function giteaFetch(endpoint: string, options: RequestInit = {}) {
-  const baseUrl = process.env.GITEA_SERVER_URL || process.env.GITHUB_SERVER_URL
+  const rawUrl = process.env.GITEA_SERVER_URL || process.env.GITHUB_SERVER_URL
   const token = process.env.GITEA_TOKEN || process.env.GITHUB_TOKEN
 
-  if (!baseUrl) throw new Error("GITEA_SERVER_URL environment variable is required")
+  if (!rawUrl) throw new Error("GITEA_SERVER_URL environment variable is required")
   if (!token) throw new Error("GITEA_TOKEN environment variable is required")
 
+  const baseUrl = normalizeBaseUrl(rawUrl)
   const url = `${baseUrl}/api/v1${endpoint}`
   const response = await fetch(url, {
     ...options,
@@ -31,6 +36,16 @@ async function giteaFetch(endpoint: string, options: RequestInit = {}) {
 
   if (!response.ok) {
     const text = await response.text()
+    if (response.status === 404) {
+      throw new Error(
+        `Gitea API error: 404 Not Found for ${url}\n` +
+        `Possible causes:\n` +
+        `  - GITEA_SERVER_URL is incorrect (current: ${rawUrl})\n` +
+        `  - Repository or PR does not exist\n` +
+        `  - Token does not have access to this resource\n` +
+        `Response: ${text}`
+      )
+    }
     throw new Error(`Gitea API error: ${response.status} ${response.statusText} - ${text}`)
   }
 

--- a/.opencode-review/tools/gitea-review.ts
+++ b/.opencode-review/tools/gitea-review.ts
@@ -25,13 +25,18 @@ interface ReviewRequest {
   }>
 }
 
+function normalizeBaseUrl(url: string): string {
+  return url.replace(/\/+$/, "").replace(/\/api\/v1\/?$/, "")
+}
+
 async function giteaFetch(endpoint: string, options: RequestInit = {}) {
-  const baseUrl = process.env.GITEA_SERVER_URL || process.env.GITHUB_SERVER_URL
+  const rawUrl = process.env.GITEA_SERVER_URL || process.env.GITHUB_SERVER_URL
   const token = process.env.GITEA_TOKEN || process.env.GITHUB_TOKEN
 
-  if (!baseUrl) throw new Error("GITEA_SERVER_URL environment variable is required")
+  if (!rawUrl) throw new Error("GITEA_SERVER_URL environment variable is required")
   if (!token) throw new Error("GITEA_TOKEN environment variable is required")
 
+  const baseUrl = normalizeBaseUrl(rawUrl)
   const url = `${baseUrl}/api/v1${endpoint}`
   const response = await fetch(url, {
     ...options,
@@ -52,6 +57,17 @@ async function giteaFetch(endpoint: string, options: RequestInit = {}) {
         `Required: write:repository scope\n` +
         `Please create a new token with write:repository permission in Gitea Settings → Applications → Access Tokens\n` +
         `Original error: ${text}`
+      )
+    }
+
+    if (response.status === 404) {
+      throw new Error(
+        `Gitea API error: 404 Not Found for ${url}\n` +
+        `Possible causes:\n` +
+        `  - GITEA_SERVER_URL is incorrect (current: ${rawUrl})\n` +
+        `  - Repository or PR does not exist\n` +
+        `  - Token does not have access to this resource\n` +
+        `Response: ${text}`
       )
     }
     

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,15 @@ LABEL org.opencontainers.image.licenses="MIT"
 # Install git and other dependencies
 RUN apk add --no-cache git curl bash
 
+# Check architecture - opencode-ai binary only supports x86_64/amd64
+# ARM users should use the source installation method instead
+RUN ARCH=$(uname -m) && \
+    if [ "$ARCH" != "x86_64" ] && [ "$ARCH" != "amd64" ]; then \
+        echo "⚠️  WARNING: opencode-ai binary may not support $ARCH architecture" && \
+        echo "   If you encounter errors, please use the source installation method:" && \
+        echo "   https://github.com/ccsert/opencode-review-gitea#installation" ; \
+    fi
+
 # Install opencode CLI globally
 RUN bun add -g opencode-ai
 

--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ docker run --rm \
 
 `REPO_NAME` can be either `repo` or `owner/repo` (entrypoint will normalize it).
 
+> **Note**: The Docker image currently only supports **x86_64/amd64** architecture. ARM devices (Raspberry Pi, etc.) should use the [Source installation](#local-testing-source) method instead.
+
 ### Local Testing (Source)
 
 ```bash

--- a/README_zh.md
+++ b/README_zh.md
@@ -175,6 +175,8 @@ docker run --rm \
 
 `REPO_NAME` 既可以传 `repo`，也可以传 `owner/repo`（entrypoint 会自动规范化）。
 
+> **注意**: Docker 镜像目前仅支持 **x86_64/amd64** 架构。ARM 设备（树莓派等）请使用[源码安装](#本地测试源码)方式。
+
 ### 本地测试（源码）
 
 ```bash

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -76,12 +76,16 @@ validate_env() {
 }
 
 infer_gitea_server_url() {
+    # Normalize: remove trailing slashes and /api/v1 suffix
     if [ -n "$GITEA_SERVER_URL" ]; then
+        export GITEA_SERVER_URL="${GITEA_SERVER_URL%/}"
+        export GITEA_SERVER_URL="${GITEA_SERVER_URL%/api/v1}"
         return 0
     fi
 
     if [ -n "$GITHUB_SERVER_URL" ]; then
-        export GITEA_SERVER_URL="$GITHUB_SERVER_URL"
+        export GITEA_SERVER_URL="${GITHUB_SERVER_URL%/}"
+        export GITEA_SERVER_URL="${GITEA_SERVER_URL%/api/v1}"
         return 0
     fi
 
@@ -204,6 +208,23 @@ print_config() {
     fi
 }
 
+check_architecture() {
+    local arch
+    arch=$(uname -m)
+    if [ "$arch" != "x86_64" ] && [ "$arch" != "amd64" ]; then
+        log_warn "Detected architecture: $arch (opencode-ai binary may not be supported)"
+        log_warn "If you encounter errors, please use the source installation method:"
+        log_warn "  https://github.com/ccsert/opencode-review-gitea#installation"
+        # Verify opencode binary actually works
+        if ! opencode --version >/dev/null 2>&1; then
+            log_error "opencode binary is not compatible with $arch architecture"
+            log_error "The pre-built Docker image only supports x86_64/amd64"
+            log_error "Please use the source installation method instead (--source)"
+            exit 1
+        fi
+    fi
+}
+
 # Main entrypoint
 main() {
     local command="${1:-review}"
@@ -211,6 +232,7 @@ main() {
     
     case "$command" in
         review)
+            check_architecture
             setup_config
             infer_gitea_server_url
             normalize_repo_context


### PR DESCRIPTION
## Summary

- **Fixes #12**: Improve Gitea API error handling. Add URL normalization (`normalizeBaseUrl`) to handle trailing slashes and `/api/v1` suffix in `GITEA_SERVER_URL`. Add detailed 404 error messages with troubleshooting hints to help users diagnose misconfiguration.
- **Fixes #14**: Add ARM architecture detection. The `opencode-ai` binary only supports x86_64/amd64. Now the Dockerfile shows a build-time warning, and the entrypoint checks at runtime whether the binary actually works on non-x86 architectures, with a clear error message pointing users to the source installation method.

## Changes

| File | Change |
|------|--------|
| `gitea-pr-diff.ts` | Add `normalizeBaseUrl()` + improved 404 error |
| `gitea-pr-files.ts` | Add `normalizeBaseUrl()` + improved 404 error |
| `gitea-review.ts` | Add `normalizeBaseUrl()` + improved 404 error |
| `gitea-comment.ts` | Add `normalizeBaseUrl()` + improved 404 error |
| `gitea-incremental-diff.ts` | Add `normalizeBaseUrl()` + improved 404 error |
| `entrypoint.sh` | Add `check_architecture()` function; normalize URL in `infer_gitea_server_url()` |
| `Dockerfile` | Add build-time architecture warning |
| `README.md` / `README_zh.md` | Document x86_64-only Docker support |

## Root Cause Analysis

**Issue #12**: The error URL `https://gitea-hosted.com/api/swagger` in the 404 response is Gitea's default error format — it's NOT generated by our code. The actual API request likely fails due to `GITEA_SERVER_URL` having trailing slashes (e.g., `https://host.com/` → `https://host.com//api/v1/...`) or including `/api/v1` already.

**Issue #14**: `opencode-ai` ships a pre-compiled binary (`.opencode`) that only supports x86_64. On ARM platforms, it fails with glibc symbol errors. This is an upstream limitation.