### PR TITLE
fix: ensure the Docker image can run opencode CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,16 @@
 # Build: docker build -t ghcr.io/ccsert/opencode-review:latest .
 # Run:   docker run --rm -v $(pwd):/workspace -e GITEA_TOKEN=xxx ghcr.io/ccsert/opencode-review
 
-FROM oven/bun:1-alpine
+FROM oven/bun:1
 
 LABEL org.opencontainers.image.source="https://github.com/ccsert/opencode-review-gitea"
 LABEL org.opencontainers.image.description="AI-powered code review for Gitea/Forgejo PRs"
 LABEL org.opencontainers.image.licenses="MIT"
 
 # Install git and other dependencies
-RUN apk add --no-cache git curl bash
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git curl bash \
+    && rm -rf /var/lib/apt/lists/*
 
 # Install opencode CLI globally
 RUN bun add -g opencode-ai

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,9 @@ LABEL org.opencontainers.image.source="https://github.com/ccsert/opencode-review
 LABEL org.opencontainers.image.description="AI-powered code review for Gitea/Forgejo PRs"
 LABEL org.opencontainers.image.licenses="MIT"
 
-# Install git and other dependencies
+# Install git and runtime dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    git curl bash \
+    git curl bash nodejs \
     && rm -rf /var/lib/apt/lists/*
 
 # Install opencode CLI globally


### PR DESCRIPTION
## Summary
- switch the Docker image to the glibc-based `oven/bun:1` base image
- install `nodejs` in the container runtime dependencies
- ensure the public `opencode` wrapper works correctly inside the image
- keep the Docker healthcheck functional with `opencode --version`

## Problem
The image built successfully, but the installed `opencode` command failed at runtime because its wrapper expected `node` to be available in `PATH`.

## Validation
- `docker build -t prueba:latest .`
- `docker run --rm --entrypoint sh prueba:latest -lc 'command -v node && node --version && command -v opencode && opencode --version'`
- `docker run --rm --entrypoint sh prueba:latest -lc 'opencode --version >/dev/null && echo healthcheck-ok'`

Closes #18 